### PR TITLE
[no squash] Fixes

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2,11 +2,13 @@
 -- =====================
 -- See README.md for licensing and other information.
 
+local S = minetest.get_translator("fachwerk")
+
 function fachwerk.register_fachwerk(basename, texture, description, craft_from)
 	local group_def = {choppy = 2, oddly_breakable_by_hand = 2, cracky = 3}
 
 	minetest.register_node(":fachwerk:" .. basename, {
-		description = "Timber-framed " .. description,
+		description = S("Timber-framed @1", description),
 		tiles = {texture .. "^fachwerk_blank.png"},
 		paramtype = "light",
 		paramtype2 = "facedir",
@@ -15,7 +17,7 @@ function fachwerk.register_fachwerk(basename, texture, description, craft_from)
 	})
 
 	minetest.register_node(":fachwerk:" .. basename .. "_1", {
-		description = "Timber-framed " .. description .. " Oblique Beam 1",
+		description = S("Timber-framed @1 (@2)", description, S("Oblique Beam 1")),
 		tiles = {
 			texture .. "^fachwerk_blank.png", -- top
 			texture .. "^fachwerk_blank.png", -- bottom
@@ -32,7 +34,7 @@ function fachwerk.register_fachwerk(basename, texture, description, craft_from)
 
 	-- TODO: is this one really needed? the node above covers most of that already
 	minetest.register_node(":fachwerk:" .. basename .. "_2", {
-		description = "Timber-framed " .. description .. " Oblique Beam 2",
+		description = S("Timber-framed @1 (@2)", description, S("Oblique Beam 2")),
 		tiles = {
 			texture .. "^fachwerk_blank.png", -- top
 			texture .. "^fachwerk_blank.png", -- bottom
@@ -48,7 +50,7 @@ function fachwerk.register_fachwerk(basename, texture, description, craft_from)
 	})
 
 	minetest.register_node(":fachwerk:" .. basename .. "_cross", {
-		description = "Timber-framed " .. description .. " Cross",
+		description = S("Timber-framed @1 (@2)", description, S("Cross")),
 		tiles = {texture .. "^fachwerk_cross.png"},
 		groups = group_def,
 		sounds = default.node_sound_stone_defaults()

--- a/default_nodes.lua
+++ b/default_nodes.lua
@@ -4,10 +4,6 @@
 
 local S = minetest.get_translator("fachwerk")
 
--- Optional fachwerk types you can enable if you like
--- Registers desert stone, white, grey and yellow wool, wood and junglewood
-local additional_fachwerk_types = false
-
 -- fachwerk.register_fachwerk(basename, texture, description, craft_from)
 fachwerk.register_fachwerk("clay", "default_clay.png", "Clay", "default:clay")
 fachwerk.register_fachwerk("brick", "default_brick.png", "Bricks", "default:brick")
@@ -15,14 +11,13 @@ fachwerk.register_fachwerk("stone_brick", "default_stone_brick.png", "Stone Bric
 fachwerk.register_fachwerk("cobble", "default_cobble.png", "Cobble", "default:cobble")
 fachwerk.register_fachwerk("stone", "default_stone.png", "Stone", "default:stone")
 
-if additional_fachwerk_types == true then
-	fachwerk.register_fachwerk("desert_stone", "default_desert_stone.png", "Desert Stone", "default:desert_stone")
-	fachwerk.register_fachwerk("white", "wool_white.png", "White Wool", "wool:white")
-	fachwerk.register_fachwerk("grey", "wool_grey.png", "Grey Wool", "wool:grey")
-	fachwerk.register_fachwerk("yellow", "wool_yellow.png", "Yellow Wool", "wool:yellow")
-	fachwerk.register_fachwerk("wood", "default_wood.png", "Wood", "default:wood")
-	fachwerk.register_fachwerk("junglewood", "default_junglewood.png", "Junglewood", "default:junglewood")
-end
+
+fachwerk.register_fachwerk("desert_stone", "default_desert_stone.png", "Desert Stone", "default:desert_stone")
+fachwerk.register_fachwerk("white", "wool_white.png", "White Wool", "wool:white")
+fachwerk.register_fachwerk("grey", "wool_grey.png", "Grey Wool", "wool:grey")
+fachwerk.register_fachwerk("yellow", "wool_yellow.png", "Yellow Wool", "wool:yellow")
+fachwerk.register_fachwerk("wood", "default_wood.png", "Wood", "default:wood")
+fachwerk.register_fachwerk("junglewood", "default_junglewood.png", "Junglewood", "default:junglewood")
 
 --
 -- Special Nodes (these are not supported by the API)

--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,1 @@
-default
+default?

--- a/init.lua
+++ b/init.lua
@@ -7,4 +7,6 @@ fachwerk = {}
 local modpath = minetest.get_modpath("fachwerk")
 
 dofile(modpath .."/api.lua")
-dofile(modpath .. "/nodes.lua")
+if minetest.get_modpath("default") then
+    dofile(modpath .. "/default_nodes.lua")
+end

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,0 +1,11 @@
+# textdomain: fachwerk
+
+##[ api.lua ]##
+Timber-framed @1=
+Timber-framed @1 (@2)=
+Oblique Beam 1=
+Oblique Beam 2=
+Cross=
+
+##[ nodes.lua ]##
+Timber-framed Glass=

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,4 @@
 name = fachwerk
 description = This mod adds timber-framed clay, bricks, cobble, stone and stone bricks to the game. There is a simple API for adding new timeber-framed nodes.
-depends = default
+optional_depends = default
+supported_games = *, minetest

--- a/nodes.lua
+++ b/nodes.lua
@@ -36,6 +36,7 @@ minetest.register_node("fachwerk:framed_glass", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	is_ground_content = false,
+	use_texture_alpha = "blend",
 	groups = {cracky = 3,oddly_breakable_by_hand = 3},
 	sounds = default.node_sound_glass_defaults(),
 })

--- a/nodes.lua
+++ b/nodes.lua
@@ -2,6 +2,8 @@
 -- =======================
 -- See README.md for licensing and other information.
 
+local S = minetest.get_translator("fachwerk")
+
 -- Optional fachwerk types you can enable if you like
 -- Registers desert stone, white, grey and yellow wool, wood and junglewood
 local additional_fachwerk_types = false
@@ -27,7 +29,7 @@ end
 --
 
 minetest.register_node("fachwerk:framed_glass", {
-	description = "Timber-framed Glass",
+	description = S("Timber-framed Glass"),
 	drawtype = "glasslike_framed_optional",
 	tiles = {"fachwerk_blank.png^default_glass_detail.png", "default_glass_detail.png"},
 	inventory_image = minetest.inventorycube("fachwerk_blank.png"),


### PR DESCRIPTION
* Allow translating item names
* Fix transparent texture on Timber-framed Glass
* Allow non-MTG games to use this mod, but without pre-registered default nodes (i.e. as API)
  * Note that I dropped the `additional_fachwerk_types` variable and instead loaded all of them, that's because (1) this should be done with `minetest.conf` in the first place and (2) I don't see a reason why this isn't the default.

This PR is ready for review.